### PR TITLE
Allow user to set OCR mimetypes

### DIFF
--- a/js/admin.elements.js
+++ b/js/admin.elements.js
@@ -34,7 +34,6 @@ var fts_tesseract_elements = {
 	tesseract_ocr: null,
 	tesseract_psm: null,
 	tesseract_lang: null,
-	tesseract_pdf: null,
 	tesseract_mimetypes: null,
 
 	init: function () {
@@ -42,13 +41,11 @@ var fts_tesseract_elements = {
 		fts_tesseract_elements.tesseract_psm = $('#tesseract_psm');
 		fts_tesseract_elements.tesseract_lang = $('#tesseract_lang');
 		fts_tesseract_elements.tesseract_ocr = $('#tesseract_ocr');
-		fts_tesseract_elements.tesseract_pdf = $('#tesseract_pdf');
 		fts_tesseract_elements.tesseract_mimetypes = $('#tesseract_mimetypes');
 
 		fts_tesseract_elements.tesseract_ocr.on('change', fts_tesseract_elements.updateSettings);
 		fts_tesseract_elements.tesseract_psm.on('change', fts_tesseract_elements.updateSettings);
 		fts_tesseract_elements.tesseract_lang.on('change', fts_tesseract_elements.updateSettings);
-		fts_tesseract_elements.tesseract_pdf.on('change', fts_tesseract_elements.updateSettings);
 		fts_tesseract_elements.tesseract_mimetypes.on('change', fts_tesseract_elements.updateSettings);
 	},
 

--- a/js/admin.elements.js
+++ b/js/admin.elements.js
@@ -35,6 +35,7 @@ var fts_tesseract_elements = {
 	tesseract_psm: null,
 	tesseract_lang: null,
 	tesseract_pdf: null,
+	tesseract_mimetypes: null,
 
 	init: function () {
 		fts_tesseract_elements.tesseract_div = $('#files_ocr-tesseract');
@@ -42,11 +43,13 @@ var fts_tesseract_elements = {
 		fts_tesseract_elements.tesseract_lang = $('#tesseract_lang');
 		fts_tesseract_elements.tesseract_ocr = $('#tesseract_ocr');
 		fts_tesseract_elements.tesseract_pdf = $('#tesseract_pdf');
+		fts_tesseract_elements.tesseract_mimetypes = $('#tesseract_mimetypes');
 
 		fts_tesseract_elements.tesseract_ocr.on('change', fts_tesseract_elements.updateSettings);
 		fts_tesseract_elements.tesseract_psm.on('change', fts_tesseract_elements.updateSettings);
 		fts_tesseract_elements.tesseract_lang.on('change', fts_tesseract_elements.updateSettings);
 		fts_tesseract_elements.tesseract_pdf.on('change', fts_tesseract_elements.updateSettings);
+		fts_tesseract_elements.tesseract_mimetypes.on('change', fts_tesseract_elements.updateSettings);
 	},
 
 

--- a/js/admin.settings.js
+++ b/js/admin.settings.js
@@ -49,7 +49,6 @@ var fts_tesseract_settings = {
 		fts_tesseract_elements.tesseract_ocr.prop('checked', (result.tesseract_enabled === '1'));
 		fts_tesseract_elements.tesseract_psm.val(result.tesseract_psm);
 		fts_tesseract_elements.tesseract_lang.val(result.tesseract_lang);
-		fts_tesseract_elements.tesseract_pdf.prop('checked', (result.tesseract_pdf === '1'));
 		fts_tesseract_elements.tesseract_mimetypes.val(result.tesseract_mimetypes);
 
 		fts_admin_settings.tagSettingsAsSaved(fts_tesseract_elements.tesseract_div);
@@ -72,7 +71,6 @@ var fts_tesseract_settings = {
 			tesseract_enabled: (fts_tesseract_elements.tesseract_ocr.is(':checked')) ? 1 : 0,
 			tesseract_psm: fts_tesseract_elements.tesseract_psm.val(),
 			tesseract_lang: fts_tesseract_elements.tesseract_lang.val(),
-			tesseract_pdf: (fts_tesseract_elements.tesseract_pdf.is(':checked')) ? 1 : 0,
 			tesseract_mimetypes: fts_tesseract_elements.tesseract_mimetypes.val()
 		};
 

--- a/js/admin.settings.js
+++ b/js/admin.settings.js
@@ -50,6 +50,7 @@ var fts_tesseract_settings = {
 		fts_tesseract_elements.tesseract_psm.val(result.tesseract_psm);
 		fts_tesseract_elements.tesseract_lang.val(result.tesseract_lang);
 		fts_tesseract_elements.tesseract_pdf.prop('checked', (result.tesseract_pdf === '1'));
+		fts_tesseract_elements.tesseract_mimetypes.val(result.tesseract_mimetypes);
 
 		fts_admin_settings.tagSettingsAsSaved(fts_tesseract_elements.tesseract_div);
 
@@ -71,7 +72,8 @@ var fts_tesseract_settings = {
 			tesseract_enabled: (fts_tesseract_elements.tesseract_ocr.is(':checked')) ? 1 : 0,
 			tesseract_psm: fts_tesseract_elements.tesseract_psm.val(),
 			tesseract_lang: fts_tesseract_elements.tesseract_lang.val(),
-			tesseract_pdf: (fts_tesseract_elements.tesseract_pdf.is(':checked')) ? 1 : 0
+			tesseract_pdf: (fts_tesseract_elements.tesseract_pdf.is(':checked')) ? 1 : 0,
+			tesseract_mimetypes: fts_tesseract_elements.tesseract_mimetypes.val()
 		};
 
 		$.ajax({

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -46,15 +46,13 @@ class ConfigService {
 	const TESSERACT_ENABLED = 'tesseract_enabled';
 	const TESSERACT_PSM = 'tesseract_psm';
 	const TESSERACT_LANG = 'tesseract_lang';
-	const TESSERACT_PDF = 'tesseract_pdf';
 	const TESSERACT_MIMETYPES = 'tesseract_mimetypes';
 
 	public $defaults = [
 		self::TESSERACT_ENABLED   => '0',
 		self::TESSERACT_PSM       => '4',
 		self::TESSERACT_LANG      => 'eng',
-		self::TESSERACT_PDF       => '0',
-		self::TESSERACT_MIMETYPES => "image/png\nimage/jpeg\nimage/tiff\nimage/vnd.djvu\napplication/pdf"
+		self::TESSERACT_MIMETYPES => "image/png,image/jpeg,image/tiff,image/vnd.djvu,application/pdf"
 	];
 
 

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -47,12 +47,14 @@ class ConfigService {
 	const TESSERACT_PSM = 'tesseract_psm';
 	const TESSERACT_LANG = 'tesseract_lang';
 	const TESSERACT_PDF = 'tesseract_pdf';
+	const TESSERACT_MIMETYPES = 'tesseract_mimetypes';
 
 	public $defaults = [
-		self::TESSERACT_ENABLED => '0',
-		self::TESSERACT_PSM     => '4',
-		self::TESSERACT_LANG    => 'eng',
-		self::TESSERACT_PDF     => '0'
+		self::TESSERACT_ENABLED   => '0',
+		self::TESSERACT_PSM       => '4',
+		self::TESSERACT_LANG      => 'eng',
+		self::TESSERACT_PDF       => '0',
+		self::TESSERACT_MIMETYPES => "image/png\nimage/jpeg\nimage/tiff\nimage/vnd.djvu\napplication/pdf"
 	];
 
 

--- a/lib/Service/TesseractService.php
+++ b/lib/Service/TesseractService.php
@@ -124,9 +124,6 @@ class TesseractService {
 	 * @param File $file
 	 */
 	private function extractContentUsingTesseractOCR(AFilesDocument &$document, File $file) {
-
-		$this->miscService->log("Starting " . $this->getAbsolutePath($file), 3);
-
 		try {
 			if ($this->configService->getAppValue(ConfigService::TESSERACT_ENABLED) !== '1') {
 				return;

--- a/lib/Service/TesseractService.php
+++ b/lib/Service/TesseractService.php
@@ -79,13 +79,7 @@ class TesseractService {
 	 * @return bool
 	 */
 	public function parsedMimeType(string $mimeType, string $extension): bool {
-		$ocrMimes = [
-			'image/png',
-			'image/jpeg',
-			'image/tiff',
-			'image/vnd.djvu',
-			'application/pdf'
-		];
+		$ocrMimes = preg_split("/\r\n|\n|\r/", $this->configService->getAppValue(ConfigService::TESSERACT_ENABLED);
 
 		foreach ($ocrMimes as $mime) {
 			if (strpos($mimeType, $mime) === 0) {
@@ -93,6 +87,7 @@ class TesseractService {
 			}
 		}
 
+		// ME: This returns only false
 		if ($mimeType === 'application/octet-stream') {
 			return $this->parsedExtension($extension);
 		}
@@ -149,11 +144,12 @@ class TesseractService {
 			// TODO: How to set options so that the index can be reset if admin settings are changed
 			//	$this->configService->setDocumentIndexOption($document, ConfigService::FILES_OCR);
 
-			if ($this->ocrPdf($document, $file)) {
-				return;
+			if ($document->getMimetype() !== 'application/pdf' && $this->configService->getAppValue(ConfigService::TESSERACT_PDF) !== '1') {
+				$this->ocrPdf($document, $file)
+			} else {
+				$content = $this->ocrFile($file);
 			}
 
-			$content = $this->ocrFile($file);
 		} catch (Exception $e) {
 			return;
 		}
@@ -206,14 +202,6 @@ class TesseractService {
 	 * @throws NotFoundException
 	 */
 	private function ocrPdf(AFilesDocument $document, File $file): bool {
-		if ($document->getMimetype() !== 'application/pdf') {
-			return false;
-		}
-
-		if ($this->configService->getAppValue(ConfigService::TESSERACT_PDF) !== '1') {
-			return true;
-		}
-
 		try {
 			$path = $this->getAbsolutePath($file);
 			$pdf = new Pdf($path);
@@ -272,6 +260,12 @@ class TesseractService {
 		$absolutePath = $view->getLocalFile($file->getPath());
 
 		return $absolutePath;
+	}
+
+	private function getMimeTypes(): string[] {
+		foreach($ocrMimes as &$row) {
+			$row = explode()
+		}
 	}
 
 

--- a/lib/Service/TesseractService.php
+++ b/lib/Service/TesseractService.php
@@ -218,9 +218,9 @@ class TesseractService {
 				$content .= $this->ocrFileFromPath($tmpPath);
 			} catch (PageDoesNotExist $e) {
 			}
-
-			return $content;
 		}
+
+		return $content;
 	}
 
 	/**

--- a/templates/settings.admin.php
+++ b/templates/settings.admin.php
@@ -80,7 +80,7 @@ Util::addScript(Application::APP_NAME, 'admin');
 			<div class="div-table-col div-table-col-left">
 				<span class="leftcol">PDF</span>
 				<br/>
-				<em>mime types to process</em>
+				<em>mime types to process, separated by <b>,</b> (comma)</em>
 			</div>
 			<div class="div-table-col">
 				<input type="text" class="big" id="tesseract_mimetypes" value=""/>

--- a/templates/settings.admin.php
+++ b/templates/settings.admin.php
@@ -76,6 +76,7 @@ Util::addScript(Application::APP_NAME, 'admin');
 			</div>
 		</div>
 
+		<!-- TODO: Remove this -->
 		<div class="div-table-row tesseract_ocr_enabled">
 			<div class="div-table-col div-table-col-left">
 				<span class="leftcol">PDF</span>
@@ -84,6 +85,17 @@ Util::addScript(Application::APP_NAME, 'admin');
 			</div>
 			<div class="div-table-col">
 				<input type="checkbox" id="tesseract_pdf" value="1"/>
+			</div>
+		</div>
+
+		<div class="div-table-row tesseract_ocr_enabled">
+			<div class="div-table-col div-table-col-left">
+				<span class="leftcol">PDF</span>
+				<br/>
+				<em>mime types to process</em>
+			</div>
+			<div class="div-table-col">
+				<textarea id="tesseract_mimetypes"></textarea>
 			</div>
 		</div>
 

--- a/templates/settings.admin.php
+++ b/templates/settings.admin.php
@@ -76,18 +76,6 @@ Util::addScript(Application::APP_NAME, 'admin');
 			</div>
 		</div>
 
-		<!-- TODO: Remove this -->
-		<div class="div-table-row tesseract_ocr_enabled">
-			<div class="div-table-col div-table-col-left">
-				<span class="leftcol">PDF</span>
-				<br/>
-				<em>enable the OCR of PDF (heavy on resource)</em>
-			</div>
-			<div class="div-table-col">
-				<input type="checkbox" id="tesseract_pdf" value="1"/>
-			</div>
-		</div>
-
 		<div class="div-table-row tesseract_ocr_enabled">
 			<div class="div-table-col div-table-col-left">
 				<span class="leftcol">PDF</span>
@@ -95,7 +83,7 @@ Util::addScript(Application::APP_NAME, 'admin');
 				<em>mime types to process</em>
 			</div>
 			<div class="div-table-col">
-				<textarea id="tesseract_mimetypes"></textarea>
+				<input type="text" class="big" id="tesseract_mimetypes" value=""/>
 			</div>
 		</div>
 


### PR DESCRIPTION
Created this to resolve an issue I had where we never need JPGs or anything indexed and only need PDF or TIFF. 

This let's the user set the indexable mimetypes and resolves https://github.com/daita/files_fulltextsearch_tesseract/issues/11 as well